### PR TITLE
Fix 32-bit address load in 64-bit AVX2 code.

### DIFF
--- a/app/extensions/blake2b/blake2b_avx2-64.inc
+++ b/app/extensions/blake2b/blake2b_avx2-64.inc
@@ -4,6 +4,7 @@ GLOBAL_HIDDEN_FN_EXT blake2b_blocks_avx2, 4, 16
 pushq %rbp
 movl $128, %r10d
 movq %rsp, %rbp
+pushq %r14
 pushq %r13
 pushq %r12
 pushq %rbx
@@ -15,6 +16,7 @@ movq 80(%rdi), %rax
 movq 64(%rdi), %r8
 movq 72(%rdi), %r9
 movq 88(%rdi), %r11
+LOAD_VAR_PIC blake2b_sigma+192, %r14
 testq %rax, %rax
 movq %rax, -64(%rsp)
 je .Lblake2b_blocks_avx2_2
@@ -93,7 +95,7 @@ vmovdqa %ymm0, %ymm2
 vmovdqa %ymm1, %ymm3
 vmovq %r8, %xmm5
 adcq $0, %r9
-movl $blake2b_sigma, %eax
+LOAD_VAR_PIC blake2b_sigma, %rax
 vpinsrq $1, %r9, %xmm5, %xmm4
 vmovdqa %ymm9, %ymm5
 vinserti128 $0x1, %xmm11, %ymm4, %ymm4
@@ -153,7 +155,7 @@ movzbl -1(%rax), %r12d
 vinserti128 $0x1, %xmm2, %ymm12, %ymm12
 movzbl -5(%rax), %r11d
 vpaddq %ymm12, %ymm13, %ymm12
-cmpq $blake2b_sigma+192, %rax
+cmpq %r14, %rax
 vmovq (%rsi,%r13), %xmm2
 vpaddq %ymm6, %ymm12, %ymm12
 vmovq (%rsi,%rbx), %xmm3
@@ -192,10 +194,11 @@ vmovdqu %ymm1, (%rdi)
 vmovdqu %ymm0, 32(%rdi)
 movq %r8, 64(%rdi)
 movq %r9, 72(%rdi)
-leaq -24(%rbp), %rsp
+leaq -32(%rbp), %rsp
 popq %rbx
 popq %r12
 popq %r13
+popq %r14
 popq %rbp
 ret
 FN_END blake2b_blocks_avx2


### PR DESCRIPTION
The new code works correctly on 64-bit systems even if the address of blake2b_sigma doesn't fit into 32 bits, and it's PIC safe.
